### PR TITLE
Terraform - Support region-specific instances within one tenant - 5th pass

### DIFF
--- a/terraform/common/base/main.tf
+++ b/terraform/common/base/main.tf
@@ -7,13 +7,6 @@ terraform {
   }
 }
 
-resource "oci_identity_compartment" "terraform" {
-  # Required
-  compartment_id = var.tenancy_id
-  description    = "Compartment for Terraform resources."
-  name           = "terraform"
-}
-
 data "oci_identity_compartments" "terraform" {
   compartment_id = var.tenancy_id
   name           = "terraform"


### PR DESCRIPTION
Temporarily remove creating the terraform compartment to allow for proper deletion of vcns