### PR TITLE
feat: Grafana Cloud Agent install and switch to TailScale API

### DIFF
--- a/cdktf/cdktf.json
+++ b/cdktf/cdktf.json
@@ -3,7 +3,7 @@
   "app": "npx ts-node main.ts",
   "projectId": "ws-V5gxjePJpgWgsGj6",
   "sendCrashReports": "false",
-  "terraformProviders": ["oracle/oci@4.100.0"],
+  "terraformProviders": ["oracle/oci@4.100.0", "tailscale/tailscale@0.13.5"],
   "terraformModules": ["oracle-terraform-modules/vcn/oci@3.5.3"],
   "context": {
     "excludeStackIdFromLogicalIds": "true",

--- a/cdktf/main.ts
+++ b/cdktf/main.ts
@@ -88,6 +88,19 @@ class InfrastructureStack extends TerraformStack {
         type: "string",
       }
     )
+    const gfCloudStackId = new TerraformVariable(
+      this,
+      "grafana_cloud_stack_id",
+      {
+        description: "Grafana Cloud Stack Id",
+        type: "string",
+      }
+    )
+    const gfCloudApiKey = new TerraformVariable(this, "grafana_cloud_api_key", {
+      description: "Grafana Cloud API key",
+      sensitive: true,
+      type: "string",
+    })
 
     const authConfig = new TerraformVariable(this, "oci", {
       description: "map containing OCI authentication information",
@@ -128,6 +141,10 @@ class InfrastructureStack extends TerraformStack {
           email: cfEmail.value,
           sshPassword: cfSshPassword.value,
           sshUsername: cfSshUsername.value,
+        },
+        grafanaConfig: {
+          stackId: gfCloudStackId.value,
+          apiKey: gfCloudApiKey.value,
         },
         terraformSshPublicKey: terraformSshPublicKey.value,
         tailscale_auth_key: tailscale_auth_key.value,

--- a/cdktf/oci/compute/main.ts
+++ b/cdktf/oci/compute/main.ts
@@ -5,7 +5,7 @@ import { Construct } from "constructs"
 import { TerraformAsset, Fn, TerraformOutput } from "cdktf"
 import * as path from "path"
 
-import { InstanceConfig } from "../main"
+import { InstanceConfig, GrafanaConfig } from "../main"
 import { CFConfig } from "../tunnel/main"
 
 interface ComputeProps {
@@ -25,6 +25,7 @@ interface ComputeProps {
     aud: string
     publicKey: string
   }
+  grafanaConfig: GrafanaConfig
   ociProvider: oci.provider.OciProvider
   tailscale_auth_key: string
 }
@@ -46,6 +47,7 @@ export class Compute extends Construct {
       cfConfig,
       cfTunnel,
       cfSshCertificate,
+      grafanaConfig,
       tailscale_auth_key,
     } = props
 
@@ -118,6 +120,8 @@ export class Compute extends Construct {
               cf_ssh_certificate: cfSshCertificate.publicKey,
               cf_ssh_username: cfConfig.sshUsername,
               cf_ssh_password: cfConfig.sshPassword,
+              grafana_cloud_stack_id: grafanaConfig.stackId,
+              grafana_cloud_api_key: grafanaConfig.apiKey,
               hostname: instance.name,
               ssh_subdomain: `${
                 instance.instance.is_subdomain

--- a/cdktf/oci/compute/setup.tpl
+++ b/cdktf/oci/compute/setup.tpl
@@ -100,3 +100,6 @@ curl -fsSL https://tailscale.com/install.sh | sh
 
 # Register node with tailscale
 sudo tailscale up --authkey "${tailscale_auth_key}"
+
+# Install Grafana Cloud Agent
+sudo ARCH=amd64 GCLOUD_STACK_ID="${grafana_cloud_stack_id}" GCLOUD_API_KEY="${grafana_cloud_api_key}" GCLOUD_API_URL="https://integrations-api-us-central.grafana.net" /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/grafanacloud-install.sh)"

--- a/cdktf/oci/compute/setup.tpl
+++ b/cdktf/oci/compute/setup.tpl
@@ -98,4 +98,4 @@ curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up --authkey "${tailscale_auth_key}"
 
 # Install Grafana Cloud Agent
-sudo GCLOUD_STACK_ID="${grafana_cloud_stack_id}" GCLOUD_API_KEY="${grafana_cloud_api_key}" GCLOUD_API_URL="https://integrations-api-us-central.grafana.net" /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/grafanacloud-install.sh)"
+sudo ARCH="$(dpkg --print-architecture)" GCLOUD_STACK_ID="${grafana_cloud_stack_id}" GCLOUD_API_KEY="${grafana_cloud_api_key}" GCLOUD_API_URL="https://integrations-api-us-central.grafana.net" /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/grafanacloud-install.sh)"

--- a/cdktf/oci/compute/setup.tpl
+++ b/cdktf/oci/compute/setup.tpl
@@ -3,11 +3,13 @@
 ARCH="$(uname -m)"
 
 if [ $ARCH = "aarch64" ]; then
-  # Install and setup Cloudflare Tunnel for ARM
-  curl https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64.deb -L -o /tmp/init-cloudflared.deb
+  ARCH=arm64
 else
-  curl https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -L -o /tmp/init-cloudflared.deb
+  ARCH=amd64
 fi
+
+# Download cloudflared deb
+curl "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${ARCH}.deb" -L -o /tmp/init-cloudflared.deb
 
 sudo dpkg -i /tmp/init-cloudflared.deb
 
@@ -102,4 +104,4 @@ curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up --authkey "${tailscale_auth_key}"
 
 # Install Grafana Cloud Agent
-sudo ARCH=amd64 GCLOUD_STACK_ID="${grafana_cloud_stack_id}" GCLOUD_API_KEY="${grafana_cloud_api_key}" GCLOUD_API_URL="https://integrations-api-us-central.grafana.net" /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/grafanacloud-install.sh)"
+sudo GCLOUD_STACK_ID="${grafana_cloud_stack_id}" GCLOUD_API_KEY="${grafana_cloud_api_key}" GCLOUD_API_URL="https://integrations-api-us-central.grafana.net" /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/grafanacloud-install.sh)"

--- a/cdktf/oci/compute/setup.tpl
+++ b/cdktf/oci/compute/setup.tpl
@@ -1,12 +1,6 @@
 #!/bin/sh
 
-ARCH="$(uname -m)"
-
-if [ $ARCH = "aarch64" ]; then
-  ARCH=arm64
-else
-  ARCH=amd64
-fi
+ARCH=$(dpkg --print-architecture)
 
 # Download cloudflared deb
 curl "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$ARCH.deb" -L -o /tmp/init-cloudflared.deb

--- a/cdktf/oci/compute/setup.tpl
+++ b/cdktf/oci/compute/setup.tpl
@@ -9,7 +9,7 @@ else
 fi
 
 # Download cloudflared deb
-curl "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${ARCH}.deb" -L -o /tmp/init-cloudflared.deb
+curl "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$ARCH.deb" -L -o /tmp/init-cloudflared.deb
 
 sudo dpkg -i /tmp/init-cloudflared.deb
 

--- a/cdktf/oci/main.ts
+++ b/cdktf/oci/main.ts
@@ -20,6 +20,11 @@ export interface InstanceConfig {
   ocpus: number
 }
 
+export interface GrafanaConfig {
+  stackId: string
+  apiKey: string
+}
+
 export interface OCIConfig {
   regions: string[]
   home_region: string
@@ -33,6 +38,7 @@ interface OCIProps {
   region: string
   compartmentId: string
   cfConfig: CFConfig
+  grafanaConfig: GrafanaConfig
   terraformSshPublicKey: string
   tailscale_auth_key: string
 }
@@ -47,6 +53,7 @@ export class OCI extends Construct {
       region,
       compartmentId,
       cfConfig,
+      grafanaConfig,
       terraformSshPublicKey,
       tailscale_auth_key,
     } = props
@@ -93,6 +100,7 @@ export class OCI extends Construct {
           subnetId: base.publicSubnet.id,
           terraformSshPublicKey: terraformSshPublicKey,
           ociProvider,
+          grafanaConfig,
           tailscale_auth_key,
         }
       )
@@ -119,6 +127,7 @@ export class MultiRegionOCI extends Construct {
       authConfig: TerraformVariable
       ociAuthPrivateKey: string
       cfConfig: CFConfig
+      grafanaConfig: GrafanaConfig
       terraformSshPublicKey: string
       tailscale_auth_key: string
     }
@@ -182,6 +191,7 @@ export class MultiRegionOCI extends Construct {
       new OCI(this, Token.asString(alias), {
         config: props.config,
         cfConfig: props.cfConfig,
+        grafanaConfig: props.grafanaConfig,
         ociProvider: ociProviders[region],
         compartmentId: identityCompartment.id,
         region,


### PR DESCRIPTION
- [x] Add Grafana Cloud agent installation to setup script
- [ ] Switch to use TailScale API and terraform to create auth key (https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_key)

:x: Currently blocked by issue #598 