### PR TITLE
Fix pihole and DNS settings

### DIFF
--- a/ansible/playbooks/roles/dns/tasks/main.yml
+++ b/ansible/playbooks/roles/dns/tasks/main.yml
@@ -1,42 +1,20 @@
 ---
-- name: Set empty normalized nameservers list
-  ansible.builtin.set_fact:
-    normalized_nameservers: []
-
-- name: Normalize nameservers
-  include_tasks: normalize_nameservers.yml
-  loop: "{{ nameservers }}"
-  loop_control:
-    loop_var: nameserver
-  when: nameservers != []
-
-- name: Print normalized nameservers
-  ansible.builtin.debug:
-    msg: "Normalized nameservers: {{ normalized_nameservers | to_json }}"
-
-# Create /etc/systemd/resolved.conf.d if it doesn't exist
-- name: Create /etc/systemd/resolved.conf.d
+# Don't let DHCP4 set DNS servers (by using dhcp4-overrides in netplan)
+- name: Disable DNS overrides
   become: true
-  ansible.builtin.file:
-    path: /etc/systemd/resolved.conf.d
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
+  ansible.builtin.blockinfile:
+    path: /etc/netplan/50-cloud-init.yaml
+    insertafter: "(\\s*)set-name: (\\S+)"
+    marker: "            # {mark} ANSIBLE MANAGED BLOCK"
+    block: "            dhcp4-overrides:\n                use-dns: false\n"
+  register: netplan_dhcp
 
-# Create drop-in file for systemd-resolved to set our nameservers
-- name: Create drop-in file for systemd-resolved
+- name: Apply new netplan
   become: true
-  ansible.builtin.copy:
-    dest: /etc/systemd/resolved.conf.d/10-dns.conf
-    content: |
-      [Resolve]
-      DNS={{ normalized_nameservers | join(' ') }}
-      Domains=~.
-    owner: root
-    group: root
-    mode: 0644
-  register: systemd_resolved_dropin
+  ansible.builtin.command: netplan apply
+  async: 5
+  poll: 1
+  when: netplan_dhcp.changed
 
 - name: Restart systemd-resolved
   become: true

--- a/ansible/playbooks/roles/dns/tasks/main.yml
+++ b/ansible/playbooks/roles/dns/tasks/main.yml
@@ -21,3 +21,15 @@
   ansible.builtin.systemd:
     name: systemd-resolved
     state: restarted
+
+# DNSSec needs to be enabled for the tailscale0 interface (using resolvectl)
+- name: Check if DNSSec is enabled for tailscale0
+  become: true
+  ansible.builtin.command: resolvectl dnssec tailscale0
+  register: resolvectl_dnssec
+
+- name: Enable DNSSec for tailscale0
+  # If DNSSec is not enabled, then previous check should end with "no"
+  when: resolvectl_dnssec.stdout | regex_search("no$")
+  become: true
+  ansible.builtin.command: resolvectl dnssec tailscale0 yes

--- a/ansible/playbooks/roles/pihole/tasks/main.yml
+++ b/ansible/playbooks/roles/pihole/tasks/main.yml
@@ -1,42 +1,30 @@
 ---
-- name: Disable stub resolver
-  become: true
-  ansible.builtin.replace:
-    path: /etc/systemd/resolved.conf
-    regexp: "#?DNSStubListener=yes"
-    replace: DNSStubListener=no
-  register: stubdisable
-
-- name: Update /etc/resolv.conf symlink
+# Create /etc/systemd/resolved.conf.d if it doesn't exist
+- name: Create /etc/systemd/resolved.conf.d
   become: true
   ansible.builtin.file:
-    src: /run/systemd/resolve/resolv.conf
-    dest: /etc/resolv.conf
-    state: link
-  register: resolvsymlink
+    path: /etc/systemd/resolved.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+# Create drop-in file for systemd-resolved to disable DNSStubListener
+- name: Create drop-in file for systemd-resolved
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/systemd/resolved.conf.d/10-stub-resolver.conf
+    content: |
+      [Resolve]
+      DNSStubListener=no
+      DNS={{ nameservers | join(' ') }}
+      Domains=~.
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Restart systemd-resolved
   become: true
   ansible.builtin.systemd:
     name: systemd-resolved
     state: restarted
-  when: stubdisable.changed or resolvsymlink.changed
-
-- name: Update netplan to 127.0.0.1 nameserver
-  become: true
-  ansible.builtin.blockinfile:
-    path: /etc/netplan/50-cloud-init.yaml
-    insertafter: "(\\s*)set-name: (\\S+)"
-    marker: "            # {mark} ANSIBLE MANAGED BLOCK"
-    block: "            dhcp4-overrides:\n                use-dns: false\n            nameservers:\n                addresses: [1.1.1.1]\n"
-  register: netplan
-
-- name: Apply new netplan
-  become: true
-  ansible.builtin.command: netplan try
-  async: 5
-  poll: 1
-  when: netplan.changed
-
-- name: Reset connection
-  ansible.builtin.meta: reset_connection

--- a/ansible/playbooks/vault.yml
+++ b/ansible/playbooks/vault.yml
@@ -15,7 +15,7 @@
     - common
     - cloudflared
     - cloudflare
-    # - dns
+    - dns
     - healthchecks
     - vault
     - docker


### PR DESCRIPTION
Tailscale overrides local DNS for all hosts. Pihole host is configured to use upstream DNS and never forward to itself, so tailscale DNS override gets ignored.

Also enables DNSSEC on tailscale interface